### PR TITLE
(fix): export Template from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fern-api/sdk",
-    "version": "0.12.2",
+    "version": "0.12.3",
     "private": false,
     "repository": "https://github.com/fern-api/fern-typescript",
     "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * as Fern from "./api";
 export { FernClient } from "./wrapper/FernClient";
 export { FernEnvironment } from "./environments";
 export { FernError, FernTimeoutError } from "./errors";
+export { Template } from "./wrapper/Template";


### PR DESCRIPTION
Previously, the `Template` class was not accessible directly from the package